### PR TITLE
nicer progress bar

### DIFF
--- a/templates/layout.html.j2
+++ b/templates/layout.html.j2
@@ -10,11 +10,17 @@
             margin-right: auto;
             font-size: 150%;
         }
-        .progressbar > div {
+        .progressbar > .bar {
             background-color: rgba(120, 255, 138, 0.753);
-            color: white;
             width: 0%;
+            height: 100%;
+        }
+        .progressbar > .label {
+            width: 100%;
+            color: white;
             text-align: center;
+            float: left;
+            line-height: 1.5em;
         }
         .progressbar {
             margin-top: 0.5em;
@@ -22,6 +28,7 @@
             width: 100%;
             height: 1.5em;
             border-radius: 0.2em;
+            overflow: hidden;
         }
 
         pre {
@@ -30,14 +37,6 @@
             border-radius: 0.2em;
         }
     </style>
-    <script>
-        function update_progressbar(id, step, total) {
-            let pr = document.getElementById(id)
-            let inner = pr.firstChild
-            inner.innerText = `${step}/${total}`;
-            inner.style.width = `${Math.round(step/total*100)}%`;
-        }
-    </script>
 </head>
 <body>
     {% block body %}

--- a/templates/upload_help.html.j2
+++ b/templates/upload_help.html.j2
@@ -66,9 +66,11 @@
 <div>
     <hr>
     <h3>File upload with curl</h3>
-    <pre><code>
-    curl "{{ url }}" -T path/to/file/to/upload.ext
-    </code></pre>
+    <pre>
+
+$ <code onclick="window.getSelection().selectAllChildren(this)">curl "{{ url }}" -T path/to/file/to/upload.ext</code>
+
+</pre>
 </div>
 
 <div>

--- a/templates/upload_help.html.j2
+++ b/templates/upload_help.html.j2
@@ -18,19 +18,31 @@
         rem.innerText = `${days}d ${hours}h ${minutes}m ${seconds}s`
     }
 
-    function update_bytes_left() {
-        let bts = document.getElementById("bytes")
-        
-        const order = Math.log2(INITIAL_MAX_SIZE_BYTES - uploaded_bytes)
+    function format_bytes(bytes) {
+        const order = Math.log2(bytes)
         const multiple = ((order / 10) | 0)
         const prefix = ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi']
-        const remaning_size_in_multiples = Math.round((INITIAL_MAX_SIZE_BYTES - uploaded_bytes) / Math.pow(2, 10*multiple) * 100) / 100
+        const remaning_size_in_multiples = bytes / Math.pow(2, 10*multiple)
 
         if (multiple < prefix.length) {
-            bts.innerText = `${remaning_size_in_multiples}${prefix[multiple]}B`
+            return `${remaning_size_in_multiples.toPrecision(4)} ${prefix[multiple]}B`
         } else {
-            bts.innerText = "a ridiculous amount"
+            return "a ridiculous amount"
         }
+    }
+
+    function update_bytes_left() {
+        let bts = document.getElementById("bytes")
+        bts.innerText = format_bytes(INITIAL_MAX_SIZE_BYTES - uploaded_bytes)
+    }
+
+
+    function update_progressbar(id, step, total) {
+        let pr = document.getElementById(id)
+        let label = pr.querySelector(".label")
+        let bar = pr.querySelector(".bar")
+        label.innerText = `${format_bytes(step)}/${format_bytes(total)}`;
+        bar.style.width = `${((step/total)*100).toFixed(2)}%`;
     }
 </script>
 
@@ -44,8 +56,8 @@
     <p>Select files you want to upload (can be more than one)</p>
     <input type="file" id="file" multiple/>
     <p id="status">No files selected...</p>
-    <div id="overall" class="progressbar"><div>&nbsp;0/0</div></div>
-    <div id="single-file" class="progressbar"><div>&nbsp;0/0</div></div>
+    <div id="overall" class="progressbar" style="display: none;"><div class="label">0/0</div><div class="bar"></div></div>
+    <div id="single-file" class="progressbar" style="display: none;"><div class="label">0/0</div><div class="bar" /></div></div>
 </div>
 
 <div>
@@ -102,6 +114,7 @@
         });
     }
     
+    /** @type HTMLInputElement */
     const fileInput = document.getElementById("file")
     const status = document.getElementById("status")
     const uploadedFiles = document.getElementById("uploaded-files")
@@ -109,15 +122,25 @@
     fileInput.onchange = async (event) => {
         let files = fileInput.files
         let totalFiles = files.length;
-        let processedFiles = 1;
+        let totalSize = [...files].map(f => f.size).reduce((a,b) => a+b, 0)
+        if (totalSize > INITIAL_MAX_SIZE_BYTES - uploaded_bytes) {
+            alert(`Cannot upload ${format_bytes(totalSize)} of data`)
+            return
+        }
+        let processedFiles = 0
+        let processedSize = 0
+
+        document.getElementById("overall").style.display = totalFiles > 1 ? "block" : "none"
+        document.getElementById("single-file").style.display = "block"
 
         for (let f of files) {
-            status.innerText = `Uploading file ${processedFiles}/${totalFiles}`
+            status.innerText = `Uploading file ${processedFiles + 1}/${totalFiles}`
 
             const initial_uploaded_bytes = uploaded_bytes
             await makeRequest("PUT", `{{ url }}${f.name}`, f, (p,t) => {
-                update_progressbar("overall", processedFiles, totalFiles)
+                update_progressbar("overall", processedSize, totalSize)
                 update_progressbar("single-file", p, t)
+                processedSize += initial_uploaded_bytes + p - uploaded_bytes
                 uploaded_bytes = initial_uploaded_bytes + p
                 update_bytes_left()
             }).catch((e) => {
@@ -135,9 +158,9 @@
         }
 
         // at the end, set all status information to final
-        status.innerText = `All ${totalFiles} files uploaded!`
-        update_progressbar("overall", totalFiles, totalFiles)
-        update_progressbar("single-file", 1, 1)
+        status.innerText = totalFiles == 1 ? "File uploaded!" : `All ${totalFiles} files uploaded!`
+        update_progressbar("overall", totalSize, totalSize)
+        update_progressbar("single-file", files[files.length - 1].size, files[files.length - 1].size)
 
         // and reset file input
         fileInput.value = "";

--- a/templates/upload_help.html.j2
+++ b/templates/upload_help.html.j2
@@ -137,7 +137,7 @@
         document.getElementById("single-file").style.display = "block"
 
         for (let f of files) {
-            status.innerText = `Uploading file ${processedFiles + 1}/${totalFiles}`
+            status.innerText = `Uploading file ${processedFiles + 1}/${totalFiles}: ${f.name}`
 
             const initial_uploaded_bytes = uploaded_bytes
             await makeRequest("PUT", `{{ url }}${f.name}`, f, (p,t) => {
@@ -161,7 +161,7 @@
         }
 
         // at the end, set all status information to final
-        status.innerText = totalFiles == 1 ? "File uploaded!" : `All ${totalFiles} files uploaded!`
+        status.innerText = totalFiles == 1 ? `File ${files[0].name} uploaded!` : `All ${totalFiles} files uploaded!`
         update_progressbar("overall", totalSize, totalSize)
         update_progressbar("single-file", files[files.length - 1].size, files[files.length - 1].size)
 

--- a/templates/upload_help.html.j2
+++ b/templates/upload_help.html.j2
@@ -16,6 +16,9 @@
         const minutes = ((seconds_remaining - days*3600*24 - hours*3600) / 60) | 0
         const seconds = ((seconds_remaining - days*3600*24 - hours*3600 - minutes*60)) | 0
         rem.innerText = `${days}d ${hours}h ${minutes}m ${seconds}s`
+
+        // The format is something like "Tuesday, 13 December 2022 at 19:26:21 CET"
+        rem.title = `Expires on ${new Date(Date.now() + seconds_remaining*1000).toLocaleString("en-GB", { dateStyle: 'full', timeStyle: 'long' })}`
     }
 
     function format_bytes(bytes) {


### PR DESCRIPTION
plus few more UI changes, sorry for merging them into a single PR, I'm lazy. If you don't like anything, I'll revert that specific change.

Before

![image](https://user-images.githubusercontent.com/7894687/209576269-eeea1015-c9f9-47aa-b9a1-839a40e0da0a.png)

After

![image](https://user-images.githubusercontent.com/7894687/209576275-d295dbc2-c201-4c85-b0e7-99a77ccea4d3.png)

The changes changes are:
* If more than the allowed size is selected for upload, it is rejected client-side instantly.
* curl command is autoselected on click to simplify copypasting to shell
* `title` of the expiration clock shows the time when it expires (in local TZ)